### PR TITLE
Bugfix: Write empty array value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ install: build
 .PHONY: vendor
 vendor: tmp/dev_image_id
 	${DOCKRUN} bash ./scripts/vendor.sh
+	@chmod 664 vendor/vendor.json
 
 # ----------------------------------------------
 # develop and test

--- a/commands_test.go
+++ b/commands_test.go
@@ -248,6 +248,22 @@ func TestWriteCmd(t *testing.T) {
 	assertResult(t, expectedOutput, result.Output)
 }
 
+func TestWriteCmd_EmptyArray(t *testing.T) {
+	content := `b: 3`
+	filename := writeTempYamlFile(content)
+	defer removeTempYamlFile(filename)
+
+	cmd := getRootCommand()
+	result := runCmd(cmd, fmt.Sprintf("write %s a []", filename))
+	if result.Error != nil {
+		t.Error(result.Error)
+	}
+	expectedOutput := `b: 3
+a: []
+`
+	assertResult(t, expectedOutput, result.Output)
+}
+
 func TestWriteCmd_Error(t *testing.T) {
 	cmd := getRootCommand()
 	result := runCmd(cmd, "write")

--- a/yaml.go
+++ b/yaml.go
@@ -343,6 +343,9 @@ func parseValue(argument string) interface{} {
 		if err == nil {
 			return value
 		}
+		if argument == "[]" {
+			return make([]interface{}, 0)
+		}
 		return argument
 	}
 	return argument[1 : len(argument)-1]


### PR DESCRIPTION
When the value is `[]` set the value to empty array instead of `'[]'`.

Resolves: #21