### PR TITLE
Bugfix: Append when array empty results in null value

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -454,6 +454,24 @@ func TestWriteCmd_Append(t *testing.T) {
 	assertResult(t, expectedOutput, result.Output)
 }
 
+func TestWriteCmd_AppendEmptyArray(t *testing.T) {
+	content := `a: 2
+`
+	filename := writeTempYamlFile(content)
+	defer removeTempYamlFile(filename)
+
+	cmd := getRootCommand()
+	result := runCmd(cmd, fmt.Sprintf("write %s b[+] v", filename))
+	if result.Error != nil {
+		t.Error(result.Error)
+	}
+	expectedOutput := `a: 2
+b:
+- v
+`
+	assertResult(t, expectedOutput, result.Output)
+}
+
 func TestMergeCmd(t *testing.T) {
 	cmd := getRootCommand()
 	result := runCmd(cmd, "merge examples/data1.yaml examples/data2.yaml")

--- a/data_navigator.go
+++ b/data_navigator.go
@@ -71,7 +71,7 @@ func writeArray(context interface{}, paths []string, value interface{}) []interf
 	case []interface{}:
 		array = context.([]interface{})
 	default:
-		array = make([]interface{}, 1)
+		array = make([]interface{}, 0)
 	}
 
 	if len(paths) == 0 {


### PR DESCRIPTION
Initialize new array as empty instead of having a single value.

Resolves: #41