### PR TITLE
Feature: Adds formatting of yaml output

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -148,8 +148,8 @@ func TestReadCmd_ArrayYaml_NoPath(t *testing.T) {
   hosts: lalaland
   name: Apply smth
   roles:
-  - lala
-  - land
+    - lala
+    - land
   serial: 1
 `
 	assertResult(t, expectedOutput, result.Output)
@@ -166,8 +166,8 @@ gather_facts: false
 hosts: lalaland
 name: Apply smth
 roles:
-- lala
-- land
+  - lala
+  - land
 serial: 1
 `
 	assertResult(t, expectedOutput, result.Output)
@@ -184,8 +184,8 @@ func TestReadCmd_ArrayYaml_Splat(t *testing.T) {
   hosts: lalaland
   name: Apply smth
   roles:
-  - lala
-  - land
+    - lala
+    - land
   serial: 1
 `
 	assertResult(t, expectedOutput, result.Output)
@@ -448,8 +448,8 @@ func TestWriteCmd_Append(t *testing.T) {
 		t.Error(result.Error)
 	}
 	expectedOutput := `b:
-- foo
-- 7
+  - foo
+  - 7
 `
 	assertResult(t, expectedOutput, result.Output)
 }
@@ -467,7 +467,7 @@ func TestWriteCmd_AppendEmptyArray(t *testing.T) {
 	}
 	expectedOutput := `a: 2
 b:
-- v
+  - v
 `
 	assertResult(t, expectedOutput, result.Output)
 }
@@ -480,8 +480,8 @@ func TestMergeCmd(t *testing.T) {
 	}
 	expectedOutput := `a: simple
 b:
-- 1
-- 2
+  - 1
+  - 2
 c:
   test: 1
 `
@@ -516,8 +516,8 @@ func TestMergeCmd_Verbose(t *testing.T) {
 	}
 	expectedOutput := `a: simple
 b:
-- 1
-- 2
+  - 1
+  - 2
 c:
   test: 1
 `
@@ -536,8 +536,8 @@ func TestMergeCmd_Inplace(t *testing.T) {
 	gotOutput := readTempYamlFile(filename)
 	expectedOutput := `a: simple
 b:
-- 1
-- 2
+  - 1
+  - 2
 c:
   test: 1`
 	assertResult(t, expectedOutput, gotOutput)

--- a/data_navigator_test.go
+++ b/data_navigator_test.go
@@ -249,7 +249,7 @@ b:
 `)
 
 	var expected = `b:
-- c: "4"`
+  - c: "4"`
 
 	updated := writeMap(data, []string{"b", "0", "c"}, "4")
 	got, _ := yamlToString(updated)
@@ -274,8 +274,8 @@ b:
 `)
 
 	var expected = `b:
-- aa
-- bb`
+  - aa
+  - bb`
 
 	updated := writeMap(data, []string{"b", "1"}, "bb")
 	got, _ := yamlToString(updated)

--- a/formatter.go
+++ b/formatter.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+func format(context interface{}) (string, error) {
+	out, err := yaml.Marshal(context)
+	if err != nil {
+		return "", fmt.Errorf("error printing yaml: %v", err)
+	}
+	var dst bytes.Buffer
+	// add error checking if indent expanded to ever return an error
+	_ = indent(&dst, out)
+
+	return dst.String(), nil
+}
+
+func indent(dst io.ByteWriter, src []byte) error {
+	for _, c := range src {
+		switch c {
+		case '-':
+			_ = dst.WriteByte(' ')
+			_ = dst.WriteByte(' ')
+			_ = dst.WriteByte(c)
+
+		default:
+			_ = dst.WriteByte(c)
+		}
+	}
+	return nil
+}

--- a/yaml.go
+++ b/yaml.go
@@ -417,11 +417,11 @@ func toString(context interface{}) (string, error) {
 }
 
 func yamlToString(context interface{}) (string, error) {
-	out, err := yaml.Marshal(context)
+	outStr, err := format(context)
 	if err != nil {
 		return "", fmt.Errorf("error printing yaml: %v", err)
 	}
-	outStr := string(out)
+
 	// trim the trailing new line as it's easier for a script to add
 	// it in if required than to remove it
 	if trimOutput {

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -99,7 +99,7 @@ func TestNewYaml_WithScript(t *testing.T) {
 	expectedResult := `b:
   c: cat
   e:
-  - name: Mike Farah`
+    - name: Mike Farah`
 	result, _ := newYaml([]string{""})
 	actualResult, _ := yamlToString(result)
 	assertResult(t, expectedResult, actualResult)


### PR DESCRIPTION
The format produced by `gopkg.in/yaml.v2` produces output while valid
is not easy to read especially for arrays.
Adds formatter to handle formatting the marshalled yaml content.
Applies similar logic used by `encoding/json.Indent`.

Resolves: #25