### PR TITLE
Fix support for Go Modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
-module "github.com/mikefarah/yaml/v2"
+module github.com/mikefarah/yaml/v2
 
 require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
+	gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
+	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Without this fix, I see the following error when building yq:

```
lab@ubu1:~/yq$ go install
go: gopkg.in/mikefarah/yaml.v2@v2.3.0: parsing go.mod: unexpected module path "gopkg.in/yaml.v2"
go: error loading module requirements

```