### PR TITLE
Rename module as actual repository path.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mikefarah/yaml.v2
+module github.com/mikefarah/yaml
 
 require (
 	gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405


### PR DESCRIPTION
This attempt worked for building 'yq' locally for me. I will send the PR for 'yq' next.